### PR TITLE
Correct calculation of sliders' value

### DIFF
--- a/app/assets/javascripts/donationSlider.js
+++ b/app/assets/javascripts/donationSlider.js
@@ -30,7 +30,10 @@ $(document).ready(function(){
   var updateAmountsAndSliders = function(event){
     var total_amount = $total_amount.val();
 
-    var target_current_amount = $('span', $(event.target).closest('.legislator_slider_block')).text();
+    // See documentation:
+    // http://foundation.zurb.com/docs/components/range_slider.html
+    // "Getting and Setting Values"
+    var target_current_amount = $(event.target).attr('data-slider');
     var target_current_percentage = (target_current_amount/total_amount)*100.00;
 
     var target_new_percentage = event.target.dataset.slider;


### PR DESCRIPTION
1.  The technique used to identify the slider that
   emitted the event was extremely complex and
   inefficient.  The documentation suggests using the
   `.attr()` method to get the value.

Simplify to follow the documentation's access
method.
1.  Do not rely on DOM `text()` value.  This means
   that if ever you access the DOM's text (while it's
   updating) it could be "" or some other
   non-numerical value.
